### PR TITLE
Preview: Initial attempt at github-flavored markdown output

### DIFF
--- a/csvdiff3/cli_diff2.py
+++ b/csvdiff3/cli_diff2.py
@@ -10,6 +10,7 @@ import colorama
 
 from .merge3 import merge3
 from .output import Diff2OutputDriver
+from .output_md import Diff2MarkdownOutputDriver
 from .file import CSVKeyError
 from .tools.options import *
 
@@ -28,12 +29,16 @@ from .tools.options import *
               help = "Enable logging in DEBUG.log")
 @click.option("-r", "--show-reordered-lines", is_flag = True, default = False,
               help = "Show unchanged but reordered lines")
+@click.option("-m", "--markdown", is_flag = True, default = False,
+              help = "Show output as markdown")
 @click.argument("file1", type=click.Path(exists = True))
 @click.argument("file2", type=click.Path(exists = True))
+@click.argument("file3", type=click.Path(exists = True), default=None)
 
-def cli_diff2(file1, file2,
+def cli_diff2(file1, file2, file3,
               colour, key,
-              debug, show_reordered_lines):
+              debug, show_reordered_lines,
+              markdown):
 
     colorama.init()
 
@@ -47,15 +52,15 @@ def cli_diff2(file1, file2,
         # For 2-way diff, we just present the same file for
         # both A and B.
         with open(file2, "rt") as file_A:
-            with open(file2, "rt") as file_B:
+            with open(file3 or file2, "rt") as file_B:
                 try:
                     rc = merge3(file_LCA, file_A, file_B, key,
                                 debug = debug,
                                 colour = colour,
                                 reformat_all = False,
-                                output_driver_class = Diff2OutputDriver,
+                                output_driver_class = (Diff2MarkdownOutputDriver if markdown else Diff2OutputDriver),
                                 output_args = output_args,
-                                filename_LCA = file1, filename_A = file2, filename_B = file2)
+                                filename_LCA = file1, filename_A = file2, filename_B = file3 or file2)
                 except MergeFailedError as e:
                     print(f"{os.path.basename(sys.argv[0])}: Error: {e.message}", file=sys.stdout)
                     sys.exit(1)

--- a/csvdiff3/merge3.py
+++ b/csvdiff3/merge3.py
@@ -7,8 +7,6 @@ import re
 import random
 import string
 
-from colorama import Fore, Style
-
 from .file import *
 from .headers import Headers
 from .tools.options import *
@@ -68,22 +66,22 @@ class __State:
         return text
 
     def text_red(self):
-        return self.text_if_colour_enabled(Fore.RED)
+        return self.text_if_colour_enabled(self.output_driver.ColorMapper.RED)
 
     def text_green(self):
-        return self.text_if_colour_enabled(Fore.GREEN)
+        return self.text_if_colour_enabled(self.output_driver.ColorMapper.GREEN)
 
     def text_cyan(self):
-        return self.text_if_colour_enabled(Fore.CYAN)
+        return self.text_if_colour_enabled(self.output_driver.ColorMapper.CYAN)
 
     def text_bold(self):
-        return self.text_if_colour_enabled(Style.BRIGHT)
+        return self.text_if_colour_enabled(self.output_driver.ColorMapper.STYLE_BRIGHT)
 
     def text_unbold(self):
-        return self.text_if_colour_enabled(Style.NORMAL)
+        return self.text_if_colour_enabled(self.output_driver.ColorMapper.STYLE_NORMAL)
 
     def text_reset(self):
-        return self.text_if_colour_enabled(Style.RESET_ALL)
+        return self.text_if_colour_enabled(self.output_driver.ColorMapper.STYLE_RESET_ALL)
 
     @staticmethod
     def dump_one_cursor(name, cursor):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 click>=6.0
 colorama
 orderedmultidict
-difflib


### PR DESCRIPTION
This is an initial attempt at Github-flavored markdown output - I have marked it preview as I know it needs changes before merge, but keen to get your thoughts the below @sctweedie .

### Limitations

* currently, it uses LaTeX for colour (as Github does not provide another way)
* as such, since the colorama approach doesn't quite match the formatting sequence for LaTex, it is a bit messy between abstracting the "bracketing" using a ColorMapper class, and inlining it in the markdown outputter - I think there's maybe a hidden fuller-featured Formatter superclass to contain the logic
* Nothing for 3-way diffs
* I haven't tracked through the branches to ensure we cover all features, but it should have most of them
* The underscore escaping is a pain, but is required to prevent Github rejecting any text inside LaTeX bounds

Really, I'd like to do this with the assumption spans are available, so we can skip the LaTeX formatting, and then `pandoc` can happily output HTML, etc. (but that does mean that the JOB_SUMMARY for Github actions will not format colour correctly) -- alternatively, using other forms of styling than colour (bold, italic, strikethrough) should work more cleanly.